### PR TITLE
Fix filename case in #include directive

### DIFF
--- a/src/QuickSortLib.h
+++ b/src/QuickSortLib.h
@@ -18,7 +18,7 @@
 #define _QuickSortLib_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-#include "arduino.h"
+#include "Arduino.h"
 #else
 #include "WProgram.h"
 #endif


### PR DESCRIPTION
Incorrect capitalization of Arduino.h caused compilation to fail on filename case-sensitive operating systems like Linux.